### PR TITLE
[HOTFIX] : solving exception raised around Infinity (using  Number.MAX_VALUE  preferably)

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -39,7 +39,7 @@
       var sseClients = [];
 
       app.get("/stream", function(req, res) {
-        req.socket.setTimeout(Infinity);
+        req.socket.setTimeout(Number.MAX_VALUE);
         res.writeHead(200, {
           'Content-Type': 'text/event-stream',
           'Cache-Control': 'no-cache',

--- a/vendor/seahorse.js
+++ b/vendor/seahorse.js
@@ -17,7 +17,7 @@
       return (i < 0) ? '' : filename.substr(i);
     },
 
-    _sendfile: function(filename, res, rate) {      
+    _sendfile: function(filename, res, rate) {
       var stream = fs.createReadStream(filename);
       var th = new Throttle(rate);
 
@@ -313,7 +313,7 @@
       var sseClients = [];
 
       app.get("/stream", function(req, res) {
-        req.socket.setTimeout(Infinity);
+        req.socket.setTimeout(Number.MAX_VALUE);
         res.writeHead(200, {
           'Content-Type': 'text/event-stream',
           'Cache-Control': 'no-cache',


### PR DESCRIPTION
### RAPPEL SUR LE BUG

L'exception suivante est levée sur Ubuntu au runTime de seahorse:

```
RangeError: msecs must be a non-negative finite number
    at Object.exports.enroll (timers.js:160:11)
    at Socket.setTimeout (net.js:337:12)
    at /usr/lib/node_modules/seahorse/vendor/seahorse.js:316:20
    at callbacks (/usr/lib/node_modules/seahorse/node_modules/express/lib/router/index.js:164:37)
...
```
### CARACTERISTIQUES PLATEFORME:

> > Ubuntu 
> > 15.0.4 
> > node --version
> > v0.12.7
> > npm --version
> > 2.11.3
### CHANGEMENTS

N.A.
### ES6

N.A. 
### DOC

N.A.
### VALIDATION

N.A.
### BACKLOG

N.A.
